### PR TITLE
adds startsWith() method

### DIFF
--- a/src/ObjectHandling/javasource/objecthandling/XPath.java
+++ b/src/ObjectHandling/javasource/objecthandling/XPath.java
@@ -170,6 +170,12 @@ public class XPath<T>
 		return this.requireBinOp(true);
 	}
 	
+	public XPath<T> startsWith(Object attr, String value)
+	{
+		autoInsertAnd().append(" starts-with(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value)).append(") ");
+		return this.requireBinOp(true);
+	}
+
 	public XPath<T> compare(Object attr, String operator, Object value) {
 		return compare(new Object[] {attr}, operator, value);
 	}


### PR DESCRIPTION
This re-adds the startsWith() method. This was removed after the Mendix 8 update of the Object Handling module, but it is still used in some of our apps. 