### PR TITLE
[RUN-3602] Generate migration file when exporting module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ import com.github.jk1.license.render.*
 
 plugins {
     id 'java'
-    id 'com.mendix.gradle.publish-module-plugin' version '1.12'
+    id 'com.mendix.gradle.publish-module-plugin' version '1.13'
     id 'net.researchgate.release' version '2.8.1'
     id 'com.github.jk1.dependency-license-report' version '2.0'
 }
@@ -27,6 +27,7 @@ mxMarketplace {
     moduleLicense = 'Apache V2'
     appDirectory = "src/ObjectHandling"
     versionPathPrefix = "_Docs/version " // the path prefix within the module to the version folder
+    createMigrationFile = true
 }
 
 def userLibDir = "$projectDir/src/ObjectHandling/userlib"
@@ -37,6 +38,12 @@ repositories {
     }
     maven {
         url 'https://nexus.rnd.mendix.com/repository/maven-hosted/'
+    }
+}
+
+configurations {
+    implementation {
+        canBeResolved = true
     }
 }
 
@@ -89,15 +96,6 @@ task copyAllToUserlib(type: Copy) {
     eachFile { fileCopyDetails -> new File(destinationDir, "${fileCopyDetails.name}.${project.name}.RequiredLib").write '' }
 }
 
-task copyRuntimeToUserlib(type: Copy) {
-    group "Build"
-    description "Copies the runtime dependencies to the userlib directory."
-
-    from configurations.runtimeClasspath
-    into userLibDir
-    eachFile { fileCopyDetails -> new File(destinationDir, "${fileCopyDetails.name}.${project.name}.RequiredLib").write '' }
-}
-
 clean {
     delete "$userLibDir"
 }
@@ -108,10 +106,6 @@ tasks.named('mxBuild') {
 
 tasks.named('compileJava') {
     dependsOn mxBuild
-}
-
-tasks.named('exportModule') {
-    dependsOn 'copyRuntimeToUserlib'
 }
 
 release {

--- a/marketplace/release-notes/4.0.1.txt
+++ b/marketplace/release-notes/4.0.1.txt
@@ -1,3 +1,5 @@
 We added startsWith, endsWith, gte, lt and lte to XPath.java.
 
 We fixed gt in XPath.java. This function was using >= instead of the correct >.
+
+Include a migration file for the Java dependencies.


### PR DESCRIPTION
Add a migration file for the dependencies.

Migration file contents:
```
dependency org.apache.commons:commons-lang3:3.12.0
dependency org.apache.commons:commons-text:1.10.0
delete commons-text-1.10.0.jar
delete commons-text-1.10.0.jar.ObjectHandling.RequiredLib
delete commons-lang3-3.12.0.jar
delete commons-lang3-3.12.0.jar.ObjectHandling.RequiredLib
```