### PR TITLE
[RUN-4148] Make the implicit conversion explicit

### DIFF
--- a/marketplace/release-notes/4.0.2.txt
+++ b/marketplace/release-notes/4.0.2.txt
@@ -1,0 +1,1 @@
+We removed "implicit narrowing conversion" which caused a warning to be made by a code scanning tool.

--- a/src/ObjectHandling/javasource/objecthandling/XPath.java
+++ b/src/ObjectHandling/javasource/objecthandling/XPath.java
@@ -528,7 +528,7 @@ public class XPath<T> {
 				break;
 
 			if (loopcount % 5 == 0)
-				sleepamount *= 1.5;
+				sleepamount = (int)(sleepamount * 1.5);
 
 			// not expired, wait a bit
 			if (result == null)


### PR DESCRIPTION
A code scanning tool gives a warning on the implicit conversion. This change is to stop the warning.

![image](https://github.com/mendix/CommunityCommons_ObjectHandling/assets/4507387/8748aed4-8777-4559-88a5-ac13c9f68ede)